### PR TITLE
Update Order.php

### DIFF
--- a/src/Entity/Requests/Order.php
+++ b/src/Entity/Requests/Order.php
@@ -169,6 +169,21 @@ class Order extends Source
 
         return $this;
     }
+    
+     /**
+     * Экспресс метод. Устанавливает адрес получателя.
+     *
+     * @param int $address адрес получателя
+     *
+     * @return self
+     */
+    public function setRecipientPostalCode(int $code)
+    {
+        $this->to_location = (is_null($this->to_location)) ? Location::withCode($code)
+            : $this->to_location->setPostalCode($code);
+
+        return $this;
+    }
 
     /**
      * Экспресс метод. Устанавливает код города отправителя.


### PR DESCRIPTION
Несколько строчек кода, которые позволяют вводить адрес получателя (при отправке до двери) с подбором города по почтовому индексу, а не по коду в базе СДЭК, чтобы не совершать лишних запросов по уточнению кода города в базе СДЭК. Мы оперируем адресами с индексами, а не кодами, из-за того, что способов доставки больше одного, нам эта функция показалась полезной.